### PR TITLE
Term sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,24 @@ data. To use it, do
 $ edges-cal run --help
 ```
 
-Multiple options exist, but the only one required is `PATH`, which should point to
+Multiple options exist, but the only ones required are `CONFIG` and `PATH`. The first
+should point to a YAML configuration for the run, and the second should point to
 a directory in which exists `S11`, `Resistance` and `Spectra` folders. Thus:
 
 ```
-$ edges-cal run .
+$ edges-cal run ~/config.yaml .
 ```
 
 will work if you are in such a directory.
+
+The `config.yaml` consists of a set of parameters passed to `edges_cal.CalibrationObservation`.
+See its docstring for more details.
+
+In addition, you can run a "term sweep" over a given calibration, iterating over number
+of Cterms and Wterms until some threshold is met. This uses the same configuration as
+`edges-cal run`, but you can pass a maximum number of C and W-terms, along with a threshold
+at which to stop the sweep (this is a threshold in absolute RMS over degrees of freedom).
+This will write out a `Calibration` file for the "best" set of parameters.
 
 ### Using the Library
 To import:

--- a/examples/settings.yaml
+++ b/examples/settings.yaml
@@ -1,0 +1,8 @@
+# An example configuration file for the `edges-cal run` and `edges-cal sweep` scripts.
+# All parameters here are passed directly to the instantiator of `CalibrationObservation`,
+# so check the docs there for more parameters.
+
+f_low: 40
+f_high: 190
+cterms: 10
+wterms: 12

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -10,6 +10,7 @@ functions in other modules.
 
 import os
 import warnings
+from copy import copy
 from functools import lru_cache
 from hashlib import md5
 from pathlib import Path
@@ -1064,6 +1065,8 @@ class CalibrationObservation:
         s11_kwargs: [None, dict] = None,
         load_spectra: [None, dict] = None,
         load_s11s: [None, dict] = None,
+        compile_from_def=True,
+        include_previous=True,
     ):
         """
         A composite object representing a full Calibration Observation.
@@ -1156,7 +1159,11 @@ class CalibrationObservation:
             run_num=run_num,
             repeat_num=repeat_num,
             fix=False,
+            compile_from_def=compile_from_def,
+            include_previous=include_previous,
         )
+        self.compiled_from_def = compile_from_def
+        self.previous_included = include_previous
 
         self.path = Path(self.io.path)
 
@@ -1833,6 +1840,8 @@ def perform_term_sweep(
     delta_rms_thresh: float = 0,
     max_cterms: int = 15,
     max_wterms: int = 15,
+    explore_run_nums: bool = False,
+    explore_repeat_nums: bool = False,
     direc=".",
     verbose=False,
 ) -> CalibrationObservation:
@@ -1853,10 +1862,20 @@ def perform_term_sweep(
         The maximum number of cterms to trial.
     max_wterms : int, optional
         The maximum number of wterms to trial.
+    explore_run_nums : bool, optional
+        Whether to iterate over S11 run numbers to find the best residuals.
+    explore_repeat_nums : bool, optional
+        Whether to iterate over S11 repeat numbers to find the best residuals.
     direc : str, optional
         Directory to write resultant :class:`Calibration` file to.
     verbose : bool, optional
         Whether to write out the RMS values derived throughout the sweep.
+
+    Notes
+    -----
+    When exploring run/repeat nums, run nums are kept constant within a load (i.e. the
+    match/short/open etc. all have either run_num=1 or run_num=2 for the same load.
+    This is physically motivated.
     """
 
     cterms = range(calobs.cterms, max_cterms)
@@ -1865,27 +1884,110 @@ def perform_term_sweep(
     rms = np.zeros((len(cterms), len(wterms)))
     winner = np.zeros(len(cterms), dtype=int)
 
-    for i, c in enumerate(cterms):
-        for j, w in enumerate(wterms):
-            calobs.update(cterms=c, wterms=w)
-            res = calobs.get_load_residuals()
-            dof = sum(len(r) for r in res.values()) - c - w
+    s11_keys = ["switching_state", "receiver_reading"] + list(io.LOAD_ALIASES.keys())
+    if explore_run_nums:
+        # Note that we don't explore run_nums for spectra/resistance, because it's rare
+        # to have those, and they'll only exist if one got completely botched (and that
+        # should be set by the user).
+        run_num = {
+            k: range(1, getattr(calobs.io.s11, k).max_run_num + 1) for k in s11_keys
+        }
+    else:
+        run_num = {k: [getattr(calobs.io.s11, k).run_num] for k in s11_keys}
+    if explore_repeat_nums:
+        rep_num = {
+            "switching_state": range(
+                1, calobs.io.s11.get_highest_rep_num("SwitchingState") + 1
+            ),
+            "receiver_reading": range(
+                1, calobs.io.s11.get_highest_rep_num("ReceiverReading") + 1
+            ),
+        }
+    else:
+        rep_num = {
+            "switching_state": [calobs.io.s11.switching_state.repeat_num],
+            "receiver_reading": [calobs.io.s11.receiver_reading.repeat_num],
+        }
 
-            rms[i, j] = np.sqrt(
-                sum(np.nansum(np.square(x)) for x in res.values()) / dof
-            )
+    for rep_key, rep_nums in rep_num.items():
+        for this_rep_num in rep_nums:
+            for run_key, run_nums in run_num.items():
+                for this_run_num in run_nums:
+                    tmp_run_num = copy(calobs.io.run_num)
+                    tmp_run_num["S11"].update({run_key: this_run_num})
 
-            if verbose:
-                print(f"Nc = {c:02}, Nw = {w:02}; RMS/dof = {rms[i, j]:1.3e}")
+                    # Change the base io.CalObs because it will change with rep/run.
+                    calobs.io = io.CalibrationObservation(
+                        path=calobs.io.path.parent,
+                        ambient_temp=calobs.io.ambient_temp,
+                        run_num=tmp_run_num,
+                        repeat_num={
+                            "switching_state": this_rep_num
+                            if rep_key == "switching_state"
+                            else calobs.io.s11.switching_state.repeat_num,
+                            "receiver_reading": this_rep_num
+                            if rep_key == "receiver_reading"
+                            else calobs.io.s11.receiver_reading.repeat_num,
+                        },
+                        fix=False,
+                        compile_from_def=calobs.compiled_from_def,
+                        include_previous=calobs.previous_included,
+                    )
 
-            # If we've decreased by more than the threshold, this #wterms becomes
-            # the new winner (for this number of cterms)
-            if j > 0 and rms[i, j] >= rms[i, j - 1] - delta_rms_thresh:
-                winner[i] = j - 1
-                break
+                    # If we are changing the receiver reading, we need to update the LNA
+                    if rep_key == "receiver_reading" or run_key == "receiver_reading":
+                        calobs.lna = LNA(
+                            calobs.io.s11.receiver_reading,
+                            internal_switch=calobs.io.s11.switching_state,
+                            f_low=calobs.freq.min,
+                            f_high=calobs.freq.max,
+                            resistance=calobs.lna.resistance,
+                        )
 
-        if i > 0 and rms[i, winner[i]] >= rms[i - 1, winner[i - 1]] - delta_rms_thresh:
-            break
+                    # If we're changing anything else, we need to change each load.
+                    if rep_key == "switching_state" or run_key != "receiver_reading":
+                        for name, load in calobs._loads.items():
+                            load.reflections = SwitchCorrection.from_path(
+                                load_name=io.LOAD_ALIASES[name],
+                                path=calobs.io.s11.path,
+                                run_num_load=this_run_num
+                                if run_key in io.LOAD_ALIASES
+                                else load.reflections.run_num,
+                                run_num_switch=this_run_num
+                                if run_key == "switching_state"
+                                else load.reflections.internal_switch.run_num,
+                                repeat_num=this_rep_num
+                                if rep_key == "switching_state"
+                                else load.reflections.internal_switch.repeat_num,
+                            )
+
+                    for i, c in enumerate(cterms):
+                        for j, w in enumerate(wterms):
+                            calobs.update(cterms=c, wterms=w)
+                            res = calobs.get_load_residuals()
+                            dof = sum(len(r) for r in res.values()) - c - w
+
+                            rms[i, j] = np.sqrt(
+                                sum(np.nansum(np.square(x)) for x in res.values()) / dof
+                            )
+
+                            if verbose:
+                                print(
+                                    f"Nc = {c:02}, Nw = {w:02}; RMS/dof = {rms[i, j]:1.3e}"
+                                )
+
+                            # If we've decreased by more than the threshold, this #wterms becomes
+                            # the new winner (for this number of cterms)
+                            if j > 0 and rms[i, j] >= rms[i, j - 1] - delta_rms_thresh:
+                                winner[i] = j - 1
+                                break
+
+                        if (
+                            i > 0
+                            and rms[i, winner[i]]
+                            >= rms[i - 1, winner[i - 1]] - delta_rms_thresh
+                        ):
+                            break
 
     calobs.update(cterms=cterms[i - 1], wterms=wterms[winner[i - 1]])
 

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -1746,10 +1746,10 @@ class CalibrationObservation:
 
         with h5py.File(filename, "w") as fl:
             # Write attributes
-            fl.attrs["path"] = self.path
+            fl.attrs["path"] = str(self.path)
             fl.attrs["cterms"] = self.cterms
             fl.attrs["wterms"] = self.wterms
-            fl.attrs["switch_path"] = self.lna.internal_switch.path
+            fl.attrs["switch_path"] = str(self.lna.internal_switch.path)
             fl.attrs["switch_run_num"] = self.lna.internal_switch.run_num
 
             fl["C1"] = self.C1_poly.coefficients

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -1764,8 +1764,10 @@ class CalibrationObservation:
 
 class Calibration:
     def __init__(self, filename):
+        self.calfile = filename
+
         with h5py.File(filename, "r") as fl:
-            self.path = fl.attrs["path"]
+            self.calobs_path = fl.attrs["path"]
             self.cterms = fl.attrs["cterms"]
             self.wterms = fl.attrs["wterms"]
 

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -13,6 +13,7 @@ import warnings
 from functools import lru_cache
 from hashlib import md5
 from pathlib import Path
+from typing import Any
 
 import h5py
 import matplotlib.pyplot as plt
@@ -154,6 +155,13 @@ class EdgesFrequencyRange(FrequencyRange):
         return np.arange(0, max_freq, fstep)
 
 
+def _get_val(val: [dict, Any], source: str):
+    try:
+        return val[source]
+    except (KeyError, TypeError):
+        return val
+
+
 class VNA:
     """
     An object representing the measurements of a VNA.
@@ -271,7 +279,12 @@ class SwitchCorrection:
     @cached_property
     def n_terms(self):
         """Number of terms to use (by default) in modelling the S11"""
-        return self._nterms or self.default_nterms.get(self.load_name, None)
+        res = self._nterms or self.default_nterms.get(self.load_name, None)
+        if not (isinstance(res, int) and res % 2):
+            raise ValueError(
+                f"n_terms must be odd for S11 models. For {self.load_name} got n_terms={res}."
+            )
+        return res
 
     @classmethod
     def from_path(
@@ -347,11 +360,9 @@ class SwitchCorrection:
 
         n_terms = n_terms or self.n_terms
 
-        if not isinstance(n_terms, int):
+        if not (isinstance(n_terms, int) and n_terms % 2):
             raise ValueError(
-                "n_terms must be an integer, got {} with load {}".format(
-                    n_terms, self.load_name
-                )
+                f"n_terms must be odd for S11 models. For {self.load_name} got n_terms={n_terms}."
             )
 
         def get_model(mag):
@@ -1039,69 +1050,106 @@ class CalibrationObservation:
 
     def __init__(
         self,
-        path,
-        semi_rigid_path=None,
-        ambient_temp=25,
-        f_low=None,
-        f_high=None,
-        run_num=None,
-        repeat_num=None,
-        resistance_f=50.009,
-        resistance_m=50.166,
-        ignore_times_percent=5,
-        cterms=5,
-        wterms=7,
-        rfi_removal="1D2D",
-        rfi_kernel_width_time=16,
-        rfi_kernel_width_freq=16,
-        rfi_threshold=6,
-        cache_dir=None,
+        path: [str, Path],
+        semi_rigid_path: [None, str, Path] = None,
+        ambient_temp: int = 25,
+        f_low: [None, float] = None,
+        f_high: [None, float] = None,
+        run_num: [None, int, dict] = None,
+        repeat_num: [None, int, dict] = None,
+        resistance_f: float = 50.009,
+        cterms: int = 5,
+        wterms: int = 7,
+        load_kwargs: [None, dict] = None,
+        s11_kwargs: [None, dict] = None,
+        load_spectra: [None, dict] = None,
+        load_s11s: [None, dict] = None,
     ):
         """
-        An composite object representing a full Calibration Observation.
+        A composite object representing a full Calibration Observation.
 
         This includes spectra of all calibrators, and methods to find the calibration
         parameters. It strictly follows Monsalve et al. (2017) in its formalism.
+        While by default the class uses the calibrator sources ("ambient", "hot_load",
+        "open", "short"), it can be modified to take other sources by setting
+        ``CalibrationObservation._sources`` to a new tuple of strings.
 
         Parameters
         ----------
-        path : str
+        path : str or Path
             Path to the directory containing all relevant measurements. It is assumed
             that in this directory is an `S11`, `Resistance` and `Spectra` directory.
-        correction_path : str, optional
-            A root to switch corrections, if different from base root.
         f_low : float, optional
-            Minimum frequency to keep.
+            Minimum frequency to keep for all loads (and their S11's). If for some
+            reason different frequency bounds are desired per-load, one can pass in
+            full load objects through ``load_spectra``.
         f_high : float, optional
-            Maximum frequency to keep.
-        run_num : int, optional
-            Identifier for the measurement files to read.
+            Maximum frequency to keep for all loads (and their S11's). If for some
+            reason different frequency bounds are desired per-load, one can pass in
+            full load objects through ``load_spectra``.
+        run_num : int or dict, optional
+            Which run number to use for the calibrators. Default is to use the last run
+            for each. Passing an int will attempt to use that run for each source. Pass
+            a dict mapping sources to numbers to use different combinations.
+        repeat_num : int or dict, optional
+            Which repeat number to use for the calibrators. Default is to use the last repeat
+            for each. Passing an int will attempt to use that repeat for each source. Pass
+            a dict mapping sources to numbers to use different combinations.
         resistance_f : float, optional
-            Female resistance (Ohms)
-        resistance_m : float, optional
-            Male resistance (Ohms)
-        ignore_times_percent : float, optional
-            Percent of time samples to reject from start of spectrum files.
+            Female resistance (Ohms). Used for the LNA S11.
         cterms : int, optional
-            Number of terms used in the polynomial model for C1 and C2.
+            The number of terms to use for the polynomial fits to the calibration
+            functions.
         wterms : int, optional
-            Number of terms used in the polynomial models for Tunc, Tcos and Tsin.
-        rfi_removal : str, optional, {'1D', '2D', '1D2D'}
-            If given, will perform median and mean-filtered xRFI over either the
-            2D waterfall, or integrated 1D spectrum. The latter is usually reasonable
-            for calibration sources, while the former is good for field data. "1D2D"
-            is a hybrid approach in which the variance per-frequency is determined
-            from the 2D data, but filtering occurs only over frequency.
-        rfi_kernel_width_time : int, optional
-            The kernel width for the detrending of data for
-            RFI removal in the time dimension (only used if `rfi_removal` is "2D").
-        rfi_kernel_width_freq : int, optional
-            The kernel width for the detrending of data for
-            RFI removal in the frequency dimension.
-        rfi_threshold : float, optional
-            The threshold (in equivalent standard deviation units) above which to
-            flag data as RFI.
+            The number of terms to use for the polynomial fits to the noise-wave
+            calibration functions.
+        load_kwargs : dict, optional
+            Keyword arguments used to instantiate the calibrator :class:`LoadSpectrum`
+            objects. See its documentation for relevant parameters. Parameters specified
+            here are used for _all_ calibrator sources.
+        s11_kwargs : dict, optional
+            Keyword arguments used to instantiate the calibrator :class:`SwitchCorrection`
+            objects. See its documentation for relevant parameters. Parameters specified
+            here are used for _all_ calibrator sources.
+        load_spectra : dict, optional
+            A dictionary mapping load names of calibration sources (eg. ambient, short)
+            to either :class:`LoadSpectrum` instances or dictionaries of keywords to
+            instantiate those objects. Useful for individually specifying
+            properties of each load separately. Values in these dictionaries (if supplied)
+            over-ride those given in ``load_kwargs`` (but values in ``load_kwargs`` are
+            still used if not over-ridden).
+        load_s11s : dict, optional
+            A dictionary mapping load names of calibration sources (eg. ambient, short)
+            to :class:`SwitchCorrection` instances or dictionaries of keywords to
+            instantiate those objects. Useful for individually specifying
+            properties of each load separately. Values in these dictionaries (if supplied)
+            over-ride those given in ``s11_kwargs`` (but values in ``s11_kwargs`` are
+            still used if not over-ridden).
+
+        Examples
+        --------
+        This will setup an observation with all default options applied:
+
+        >>> path = '/data5/edges/data/CalibrationObservations/Receiver01_2019_11_26_040_to_200MHz'
+        >>> calobs = CalibrationObservation(path)
+
+        To specify some options for constructing the various calibrator load spectra:
+
+        >>> calobs = CalibrationObservation(path, load_kwargs={"cache_dir":".", "ignore_times_percent": 50})
+
+        But if we typically wanted 50% of times ignored, but in one special case we'd like 80%:
+
+        >>> calobs = CalibrationObservation(path, load_kwargs={"cache_dir":".", "ignore_times_percent": 50},
+        >>>                                 load_spectra={"short": {"ignore_times_percent": 80}})
+
         """
+        load_spectra = load_spectra or {}
+        load_s11s = load_s11s or {}
+        load_kwargs = load_kwargs or {}
+        s11_kwargs = s11_kwargs or {}
+        assert all(name in self._sources for name in load_spectra)
+        assert all(name in self._sources for name in load_s11s)
+
         self.io = io.CalibrationObservation(
             path,
             ambient_temp=ambient_temp,
@@ -1110,7 +1158,7 @@ class CalibrationObservation:
             fix=False,
         )
 
-        self.path = self.io.path
+        self.path = Path(self.io.path)
 
         hot_load_correction = HotLoadCorrection(
             semi_rigid_path
@@ -1123,26 +1171,34 @@ class CalibrationObservation:
 
         self._loads = {}
         for source in self._sources:
-            load = LoadSpectrum(
-                spec_obj=getattr(self.io.spectra, source),
-                resistance_obj=getattr(self.io.resistance, source),
-                f_low=f_low,
-                f_high=f_high,
-                ignore_times_percent=ignore_times_percent,
-                rfi_removal=rfi_removal,
-                rfi_kernel_width_freq=rfi_kernel_width_freq,
-                rfi_kernel_width_time=rfi_kernel_width_time,
-                rfi_threshold=rfi_threshold,
-                cache_dir=cache_dir,
-            )
+            load = load_spectra.get(source, {})
 
-            refl = SwitchCorrection(
-                getattr(self.io.s11, source),
-                self.io.s11.switching_state,
-                f_low=f_low,
-                f_high=f_high,
-                resistance=resistance_m,
-            )
+            if isinstance(load, dict):
+                load = LoadSpectrum(
+                    spec_obj=getattr(self.io.spectra, source),
+                    resistance_obj=getattr(self.io.resistance, source),
+                    f_low=f_low,
+                    f_high=f_high,
+                    **{**load_kwargs, **load},
+                )
+
+            # Ensure that we finally have a LoadSpectrum
+            if not isinstance(load, LoadSpectrum):
+                raise ValueError(
+                    "load_spectra must be a dict of LoadSpectrum or dicts."
+                )
+
+            refl = load_s11s.get(source, {})
+
+            if isinstance(refl, dict):
+                refl = SwitchCorrection(
+                    getattr(self.io.s11, source),
+                    self.io.s11.switching_state,
+                    f_low=f_low,
+                    f_high=f_high,
+                    **{**s11_kwargs, **refl},
+                )
+
             if source == "hot_load":
                 self._loads[source] = Load(
                     load,
@@ -1153,10 +1209,8 @@ class CalibrationObservation:
             else:
                 self._loads[source] = Load(load, refl)
 
-        self.short = self._loads["short"]
-        self.open = self._loads["open"]
-        self.hot_load = self._loads["hot_load"]
-        self.ambient = self._loads["ambient"]
+        for name, load in self._loads.items():
+            setattr(self, name, load)
 
         self.lna = LNA(
             self.io.s11.receiver_reading,
@@ -1166,16 +1220,39 @@ class CalibrationObservation:
             resistance=resistance_f,
         )
 
+        # We must use the most restricted frequency range available from all available
+        # sources as well as the LNA.
+        fmin = max(
+            sum(
+                (
+                    [load.spectrum.freq.min, load.reflections.freq.min]
+                    for load in self._loads.values()
+                ),
+                [],
+            )
+            + [self.lna.freq.min]
+        )
+
+        fmax = min(
+            sum(
+                (
+                    [load.spectrum.freq.max, load.reflections.freq.max]
+                    for load in self._loads.values()
+                ),
+                [],
+            )
+            + [self.lna.freq.max]
+        )
+
+        if fmax <= fmin:
+            raise ValueError(
+                "The inputs loads and S11s have non-overlapping frequency ranges!"
+            )
+
+        self.freq = EdgesFrequencyRange(f_low=fmin, f_high=fmax)
+
         self.cterms = cterms
         self.wterms = wterms
-
-        # Expose a Frequency object
-        self.freq = self.ambient.freq
-
-        if self.lna.freq.min > self.freq.min or self.lna.freq.max < self.freq.max:
-            raise ValueError(
-                f"The LNA S11 measurements have a smaller frequency range than requested from the loads. Set f_low >= {self.lna.freq.min} and f_high <= {self.lna.freq.max}"
-            )
 
     def new_load(
         self,

--- a/src/edges_cal/cli.py
+++ b/src/edges_cal/cli.py
@@ -85,6 +85,15 @@ def run(config, path, out, cache_dir, plot, simulators):
     "-w", "--max-wterms", type=int, default=20, help="maximum number of wterms"
 )
 @click.option(
+    "-r/-R",
+    "--repeats/--no-repeats",
+    default=False,
+    help="explore repeats of switch and receiver s11",
+)
+@click.option(
+    "-n/-N", "--runs/--no-runs", default=False, help="explore runs of s11 measurements"
+)
+@click.option(
     "-t",
     "--delta-rms-thresh",
     type=float,
@@ -105,7 +114,17 @@ def run(config, path, out, cache_dir, plot, simulators):
     default=".",
     help="directory in which to keep/search for the cache",
 )
-def sweep(config, path, max_cterms, max_wterms, delta_rms_thresh, out, cache_dir):
+def sweep(
+    config,
+    path,
+    max_cterms,
+    max_wterms,
+    repeats,
+    runs,
+    delta_rms_thresh,
+    out,
+    cache_dir,
+):
     with open(config, "r") as fl:
         settings = yaml.load(fl, Loader=yaml.FullLoader)
 
@@ -113,11 +132,14 @@ def sweep(config, path, max_cterms, max_wterms, delta_rms_thresh, out, cache_dir
         settings.update(cache_dir=cache_dir)
 
     obs = cc.CalibrationObservation(path=path, **settings)
+
     cc.perform_term_sweep(
         obs,
         direc=out,
         verbose=True,
         max_cterms=max_cterms,
         max_wterms=max_wterms,
+        explore_repeat_nums=repeats,
+        explore_run_nums=runs,
         delta_rms_thresh=delta_rms_thresh,
     )

--- a/src/edges_cal/cli.py
+++ b/src/edges_cal/cli.py
@@ -1,51 +1,95 @@
-import logging
 from os.path import join
 
 import click
+import yaml
 
 from edges_cal import cal_coefficients as cc
-
-from . import io
-from .logging import logger
 
 main = click.Group()
 
 
 @main.command()
+@click.argument("config", type=click.Path(dir_okay=False, file_okay=True, exists=True))
 @click.argument("path", type=click.Path(dir_okay=True, file_okay=False, exists=True))
 @click.option(
-    "-f", "--f-low", type=float, default=None, help="minimum frequency to calibrate"
+    "-o",
+    "--out",
+    type=click.Path(dir_okay=True, file_okay=False, exists=True),
+    default=".",
+    help="output directory",
 )
 @click.option(
-    "-F", "--f-high", type=float, default=None, help="maximum frequency to calibrate"
+    "-c",
+    "--cache-dir",
+    type=click.Path(dir_okay=True, file_okay=False),
+    default=".",
+    help="directory in which to keep/search for the cache",
 )
-@click.option("-n", "--run-num", type=int, default=None, help="run number to read")
 @click.option(
-    "-p",
-    "--ignore_times_percent",
+    "-p/-P",
+    "--plot/--no-plot",
+    default=True,
+    help="whether to make diagnostic plots of calibration solutions.",
+)
+@click.option(
+    "-s",
+    "--simulators",
+    multiple=True,
+    default=[],
+    help="antenna simulators to create diagnostic plots for.",
+)
+def run(config, path, out, cache_dir, plot, simulators):
+    """
+    Calibrate using lab measurements in PATH, and make all relevant plots.
+    """
+    with open(config, "r") as fl:
+        settings = yaml.load(fl, Loader=yaml.FullLoader)
+
+    if cache_dir != ".":
+        settings.update(cache_dir=cache_dir)
+
+    obs = cc.CalibrationObservation(path=path, **settings)
+
+    if plot:
+        # Plot Calibrator properties
+        fig = obs.plot_raw_spectra()
+        fig.savefig(join(out, "raw_spectra.png"))
+
+        figs = obs.plot_s11_models()
+        for kind, fig in figs.items():
+            fig.savefig(join(out, f"{kind}_s11_model.png"))
+
+        fig = obs.plot_calibrated_temps(bins=256)
+        fig.savefig(join(out, "calibrated_temps.png"))
+
+        fig = obs.plot_coefficients()
+        fig.savefig(join(out, "calibration_coefficients.png"))
+
+        # Calibrate and plot antsim
+        for name in simulators:
+            antsim = obs.new_load(load_name=name)
+            fig = obs.plot_calibrated_temp(antsim, bins=256)
+            fig.savefig(join(out, f"{name}_calibrated_temp.png"))
+
+    # Write out data
+    obs.write(join(out, str(obs.path.parent.name)))
+
+
+@main.command()
+@click.argument("config", type=click.Path(dir_okay=False, file_okay=True, exists=True))
+@click.argument("path", type=click.Path(dir_okay=True, file_okay=False, exists=True))
+@click.option(
+    "-c", "--max-cterms", type=int, default=20, help="maximum number of cterms"
+)
+@click.option(
+    "-w", "--max-wterms", type=int, default=20, help="maximum number of wterms"
+)
+@click.option(
+    "-t",
+    "--delta-rms-thresh",
     type=float,
-    default=5,
-    help="percentage of data at start of files to ignore",
-)
-@click.option(
-    "-r",
-    "--resistance-f",
-    type=float,
-    default=50.0002,
-    help="female resistance standard",
-)
-@click.option(
-    "-R", "--resistance-m", type=float, default=50.166, help="male resistance standard"
-)
-@click.option(
-    "-C", "--c-terms", type=int, default=11, help="number of terms to fit for C1 and C2"
-)
-@click.option(
-    "-W",
-    "--w-terms",
-    type=int,
-    default=12,
-    help="number of terms to fit for TC, TS and TU",
+    default=0,
+    help="threshold marking rms convergence",
 )
 @click.option(
     "-o",
@@ -61,53 +105,19 @@ main = click.Group()
     default=".",
     help="directory in which to keep/search for the cache",
 )
-def run(
-    path,
-    f_low,
-    f_high,
-    run_num,
-    ignore_times_percent,
-    resistance_f,
-    resistance_m,
-    c_terms,
-    w_terms,
-    out,
-    cache_dir,
-):
-    """
-    Calibrate using lab measurements in PATH, and make all relevant plots.
-    """
-    obs = cc.CalibrationObservation(
-        path=path,
-        f_low=f_low,
-        f_high=f_high,
-        run_num=run_num,
-        ignore_times_percent=ignore_times_percent,
-        resistance_f=resistance_f,
-        resistance_m=resistance_m,
-        cterms=c_terms,
-        wterms=w_terms,
-        cache_dir=cache_dir,
+def sweep(config, path, max_cterms, max_wterms, delta_rms_thresh, out, cache_dir):
+    with open(config, "r") as fl:
+        settings = yaml.load(fl, Loader=yaml.FullLoader)
+
+    if cache_dir != ".":
+        settings.update(cache_dir=cache_dir)
+
+    obs = cc.CalibrationObservation(path=path, **settings)
+    cc.perform_term_sweep(
+        obs,
+        direc=out,
+        verbose=True,
+        max_cterms=max_cterms,
+        max_wterms=max_wterms,
+        delta_rms_thresh=delta_rms_thresh,
     )
-
-    # Plot Calibrator properties
-    fig = obs.plot_raw_spectra()
-    fig.savefig(join(out, "raw_spectra.png"))
-
-    figs = obs.plot_s11_models()
-    for kind, fig in figs.items():
-        fig.savefig(join(out, f"{kind}_s11_model.png"))
-
-    fig = obs.plot_calibrated_temps(bins=256)
-    fig.savefig(join(out, "calibrated_temps.png"))
-
-    fig = obs.plot_coefficients()
-    fig.savefig(join(out, "calibration_coefficients.png"))
-
-    # Calibrate and plot antsim
-    antsim = obs.new_load(load_name="AntSim3")
-    fig = obs.plot_calibrated_temp(antsim, bins=256)
-    fig.savefig(join(out, "antsim_calibrated_temp.png"))
-
-    # Write out data
-    obs.write_coefficients()

--- a/src/edges_cal/xrfi.py
+++ b/src/edges_cal/xrfi.py
@@ -669,6 +669,7 @@ def xrfi_poly(
     increase_order=True,
     decrement_threshold=0,
     min_threshold=5,
+    return_models=False,
     inplace=True,
 ):
     """
@@ -756,7 +757,8 @@ def xrfi_poly(
 
         par = np.polyfit(ff, s, n_signal)
         model = np.polyval(par, f)
-        model_list.append(par)
+        if return_models:
+            model_list.append(par)
         if t_log:
             model = np.exp(model)
 
@@ -766,7 +768,8 @@ def xrfi_poly(
             ff, np.abs(res[~flags]), n_resid if n_resid > 0 else n_signal + n_resid
         )
         model_std = np.polyval(par, f)
-        model_std_list.append(par)
+        if return_models:
+            model_std_list.append(par)
 
         if accumulate:
             nflags = np.sum(flags[~flags])
@@ -806,5 +809,6 @@ def xrfi_poly(
             "total_flags": total_flags_list,
             "models": model_list,
             "model_std": model_std_list,
+            "n_iters": counter,
         },
     )


### PR DESCRIPTION
Adds a function to do a term sweep over a number of terms. 

Still, there's the possibility of adding iterations over run_num/repeat_num here, which is not yet implemented. Also, the RMS is taken over the calibration sources (hot/ambient/short/long), and ignores any possible antenna simulators. Not sure if this is the right way to do things. 

We can add those separately in another PR if they seem useful.

I know @gitul has done a bit of this before, so would be happy to have his comments.