### PR TITLE
fix: watershed xrfi needs to return info dict

### DIFF
--- a/src/edges_cal/xrfi.py
+++ b/src/edges_cal/xrfi.py
@@ -887,6 +887,8 @@ def xrfi_watershed(
     -------
     ndarray :
         Boolean array of flags.
+    dict :
+        Information about the flagging procedure (empty for this function)
     """
     if flags is None:
         raise ValueError("You must provide flags as an ndarray")
@@ -903,4 +905,4 @@ def xrfi_watershed(
     time_coll = np.sum(fl, axis=0)
     time_mask = time_coll > tol[1] * flags.shape[0]
     fl[:, time_mask] = True
-    return fl
+    return fl, {}

--- a/tests/test_xrfi.py
+++ b/tests/test_xrfi.py
@@ -249,13 +249,13 @@ def test_poly_watershed_relaxed(sky_model, rfi_model, scale):
 
 def test_watershed():
     rfi = np.zeros((10, 10), dtype=bool)
-    out = xrfi.xrfi_watershed(flags=rfi)
+    out, _ = xrfi.xrfi_watershed(flags=rfi)
     assert not np.any(out)
 
     rfi = np.ones((10, 10), dtype=bool)
-    out = xrfi.xrfi_watershed(flags=rfi)
+    out, _ = xrfi.xrfi_watershed(flags=rfi)
     assert np.all(out)
 
     rfi = np.repeat([0, 1], 48).reshape((3, 32))
-    out = xrfi.xrfi_watershed(flags=rfi, tol=0.2)
+    out, _ = xrfi.xrfi_watershed(flags=rfi, tol=0.2)
     assert np.all(out)


### PR DESCRIPTION
This normalises the _output_ of `xrfi_watershed`.