### PR TITLE
Suppress rcond warning

### DIFF
--- a/src/edges_cal/modelling.py
+++ b/src/edges_cal/modelling.py
@@ -2,6 +2,7 @@
 """Functions for generating least-squares model fits for linear models."""
 import numpy as np
 import scipy as sp
+import warnings
 from abc import abstractmethod
 from cached_property import cached_property
 from typing import Sequence, Type, Union
@@ -338,7 +339,9 @@ class ModelFit:
 
         Wydata = np.dot(np.sqrt(self.weights), ydata)
         q, r = self.qr
-        return sp.linalg.solve(r, np.dot(q.T, Wydata)).flatten()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return sp.linalg.solve(r, np.dot(q.T, Wydata)).flatten()
 
     def evaluate(self, x: [np.ndarray, None] = None) -> np.ndarray:
         """Evaluate the best-fit model.

--- a/src/edges_cal/xrfi.py
+++ b/src/edges_cal/xrfi.py
@@ -863,7 +863,7 @@ def xrfi_poly(spectrum: np.ndarray, **kwargs):
 def xrfi_watershed(
     spectrum: [None, np.ndarray] = None,
     flags: [None, np.ndarray] = None,
-    tol: [float, Tuple[float]] = 0.2,
+    tol: [float, Tuple[float]] = 0.5,
     inplace=False,
 ):
     """Apply a watershed over frequencies and times for flags.


### PR DESCRIPTION
This suppresses the ill-conditioned matrix warning when solving the matrix equation in `modelling.py`. I'm still not absolutely convinced that's a good idea (perhaps we should rather be _fixing_ it), but most things I find seem to say it should be fine (and we're getting reasonable results for now).