### PR TITLE
fix: pass parameters through from Foreground

### DIFF
--- a/src/edges_cal/modelling.py
+++ b/src/edges_cal/modelling.py
@@ -260,7 +260,7 @@ class Foreground(Model, is_meta=True):
             The model evaluated at the input ``x`` or ``basis``.
         """
         t = 2.725 if self.with_cmb else 0
-        return t + super().__call__(x)
+        return t + super().__call__(x=x, basis=basis, parameters=parameters)
 
 
 class PhysicalLin(Foreground):


### PR DESCRIPTION
Fixes a small bug where parameters passed to __call__() from `Foreground` weren't passed through.