### PR TITLE
fix: don't check for internal switch goodness

### DIFF
--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -2007,7 +2007,7 @@ class Calibration:
                 self.internal_switch = io.SwitchingState(
                     fl.attrs["switch_path"], run_num=fl.attrs["switch_run_num"],
                 )
-            except ValueError:
+            except (ValueError, io.utils.FileStructureError):
                 self.internal_switch = None
 
     def lna_s11(self, freq=None):

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -2005,9 +2005,7 @@ class Calibration:
 
             try:
                 self.internal_switch = io.SwitchingState(
-                    fl.attrs["switch_path"],
-                    run_num=fl.attrs["switch_run_num"],
-                    check=False,
+                    fl.attrs["switch_path"], run_num=fl.attrs["switch_run_num"],
                 )
             except ValueError:
                 self.internal_switch = None

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -2003,9 +2003,14 @@ class Calibration:
             self._lna_s11_rl = Spline(self.freq.freq, fl["lna_s11_real"][...])
             self._lna_s11_im = Spline(self.freq.freq, fl["lna_s11_imag"][...])
 
-            self.internal_switch = io.SwitchingState(
-                fl.attrs["switch_path"], run_num=fl.attrs["switch_run_num"]
-            )
+            try:
+                self.internal_switch = io.SwitchingState(
+                    fl.attrs["switch_path"],
+                    run_num=fl.attrs["switch_run_num"],
+                    check=False,
+                )
+            except ValueError:
+                self.internal_switch = None
 
     def lna_s11(self, freq=None):
         """Get the LNA S11 at given frequencies."""
@@ -2123,6 +2128,7 @@ class Calibration:
             The calibrated temperature.
         """
         uncal_temp = 400 * q + 300
+
         return self.calibrate_temp(freq, uncal_temp, ant_s11)
 
 

--- a/tests/test_cal_coeff.py
+++ b/tests/test_cal_coeff.py
@@ -263,6 +263,12 @@ def test_calibration_init(cal_data: Path, tmpdir: Path):
         cal.decalibrate_temp(calobs.freq.freq, cal_temp, s11)[mask], temp[mask]
     )
 
+    with h5py.File(tmpdir / "calfile.h5", "a") as fl:
+        fl.attrs["switch_path"] = "/doesnt/exist"
+
+    cal = cc.Calibration(tmpdir / "calfile.h5")
+    assert cal.internal_switch is None
+
 
 def test_term_sweep(cal_data: Path, tmpdir: Path):
     cache = tmpdir / "cal-coeff-cache"


### PR DESCRIPTION
This makes it possible to pass in a different manual directory for the switch correction in a `Calibration` object(eg. if the calfile is downloaded to a different computer, the link to the switch correction will not work). 

It might be worthwhile -- in the future -- just saving the switch correction data into the calfile itself.