### PR TITLE
fix: frequencies for edges spectrometer were slightly off

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/home/smurray/miniconda3/envs/edges/bin/python"
+}

--- a/src/edges_cal/tools.py
+++ b/src/edges_cal/tools.py
@@ -172,6 +172,4 @@ class EdgesFrequencyRange(FrequencyRange):
         freqs: 1D-array
             full frequency array from 0 to 200 MHz, at raw resolution
         """
-        # Full frequency vector
-        fstep = max_freq / n_channels
-        return np.arange(0, max_freq, fstep)
+        return np.linspace(0, max_freq, n_channels)

--- a/tests/test_freq.py
+++ b/tests/test_freq.py
@@ -1,7 +1,7 @@
 """Test frequency range classes."""
 import numpy as np
 
-from edges_cal import FrequencyRange
+from edges_cal import EdgesFrequencyRange, FrequencyRange
 
 
 def test_freq_class():
@@ -9,3 +9,18 @@ def test_freq_class():
     freq = FrequencyRange(np.linspace(0, 10, 100), f_low=1, f_high=7)
     assert freq.freq.max() <= 7
     assert freq.freq.min() >= 1
+
+
+def test_edges_freq():
+    freq = EdgesFrequencyRange()
+    assert freq.min == 0.0
+    assert freq.max == 200.0
+    assert len(freq.freq) == 32768
+    assert np.isclose(freq.df, 0.0061037, atol=1e-7)
+
+
+def test_edges_freq_limited():
+    freq = EdgesFrequencyRange(f_low=50.0, f_high=100.0)
+    assert len(freq.freq) == 8192
+    assert freq.min > 50.0
+    assert freq.max < 100.0


### PR DESCRIPTION
This makes the frequencies in the lab calibration actually match those that are measured and stored in .acq files.