### PR TITLE
feat: updated modelling API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ devel/output/*
 src/edges_cal/notebooks/.ipynb_checkpoints
 src/edges_cal/notebooks/*.h5
 .vscode/
+prof/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## dev
+
+### Changed
+
+- `modelling` module got an overhaul. It now consists of smaller, self-consistent
+  classes that are based on `attrs` and are read-only (but clonable). There is an
+  explicit split between a `Model` and a `FixedLinearModel` which is defined at some
+  coordinates `x`, allowing the latter to provide speedups for fitting lots of data at
+  the same coordinates. They are also YAML-read/writable.
+
+
 ## 0.7.0
 
 ### Added

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -27,7 +27,9 @@ from . import modelling as mdl
 from . import receiver_calibration_func as rcf
 from . import reflection_coefficient as rc
 from . import s11_correction as s11
-from . import tools, xrfi
+from . import tools
+from . import types as tp
+from . import xrfi
 from .cached_property import cached_property
 from .tools import EdgesFrequencyRange, FrequencyRange
 
@@ -35,10 +37,10 @@ from .tools import EdgesFrequencyRange, FrequencyRange
 class S1P:
     def __init__(
         self,
-        s1p: [str, Path, io.S1P],
-        f_low=None,
-        f_high=None,
-        switchval: [int, None] = None,
+        s1p: tp.PathLike | io.S1P,
+        f_low: float | None = None,
+        f_high: float | None = None,
+        switchval: int | None = None,
     ):
         """
         An object representing the measurements of a VNA.
@@ -108,7 +110,7 @@ class _S11Base(metaclass=ABCMeta):
         f_low: Optional[float] = None,
         f_high: Optional[float] = None,
         n_terms: Optional[int] = None,
-        model_type: str = "fourier",
+        model_type: tp.Modelable = "fourier",
     ):
         """
         A class representing relevant switch corrections for a load.
@@ -190,7 +192,7 @@ class _S11Base(metaclass=ABCMeta):
 
     @lru_cache()
     def get_corrected_s11_model(
-        self, n_terms: Union[int, None] = None, model_type: Union[None, str] = None,
+        self, n_terms: int | None = None, model_type: tp.Modelable | None = None,
     ):
         """Generate a callable model for the S11 correction.
 
@@ -214,13 +216,9 @@ class _S11Base(metaclass=ABCMeta):
             If n_terms is not an integer, or not odd.
         """
         n_terms = n_terms or self.n_terms
-        model_type = model_type or self.model_type
-
-        if not (isinstance(n_terms, int) and n_terms % 2):
-            raise ValueError(
-                f"n_terms must be odd for S11 models. For {self.load_name} got "
-                f"n_terms={n_terms}."
-            )
+        model_type = mdl.get_mdl(model_type or self.model_type)
+        model = model_type(n_terms=n_terms)
+        emodel = model.at(x=self.freq.freq_recentred)
 
         s11_correction = self.corrected_load_s11
 
@@ -230,10 +228,8 @@ class _S11Base(metaclass=ABCMeta):
 
             d = np.abs(s11_correction) if mag else np.unwrap(np.angle(s11_correction))
 
-            fit = mdl.ModelFit(
-                model_type, xdata=self.freq.freq_recentred, ydata=d, n_terms=n_terms
-            )
-            return lambda x: fit.evaluate(x)
+            fit = emodel.fit(ydata=d)
+            return fit.evaluate
 
         mag = get_model(True)
         ang = get_model(False)
@@ -344,14 +340,13 @@ class LoadS11(_S11Base):
     def from_path(
         cls,
         load_name: str,
-        path: [str, Path],
+        path: tp.PathLike,
         run_num_load: int = 1,
         run_num_switch: int = 1,
         repeat_num_load: int = None,
         repeat_num_switch: int = None,
         resistance: float = 50.166,
-        model_type_internal_switch: Union[str, mdl.Model] = "polynomial",
-        n_terms_internal_switch: int = 7,
+        model_internal_switch: mdl.Model = mdl.Polynomial(n_terms=7),
         **kwargs,
     ):
         """
@@ -392,8 +387,7 @@ class LoadS11(_S11Base):
                 repeat_num=repeat_num_switch,
             ),
             resistance=resistance,
-            model=model_type_internal_switch,
-            n_terms=n_terms_internal_switch,
+            model=model_internal_switch,
         )
         return cls(load_s11=s11_load_dir, internal_switch=internal_switch, **kwargs)
 
@@ -984,9 +978,8 @@ class HotLoadCorrection:
         """
         d = self.data[:, self._kinds[kind]]
         d = np.abs(d) if mag else np.unwrap(np.angle(d))
-        mag = mdl.ModelFit(
-            "polynomial", xdata=self.freq.freq_recentred, ydata=d, n_terms=21
-        )
+        model = mdl.Polynomial(n_terms=21)
+        mag = model.fit(xdata=self.freq.freq_recentred, ydata=d)
 
         def out(f):
             ff = self.freq.normalize(f)
@@ -2076,7 +2069,7 @@ class CalibrationObservation:
             fl.attrs["switch_repeat_num"] = self.internal_switch.data.repeat_num
             fl.attrs["switch_resistance"] = self.internal_switch.resistance
             fl.attrs["switch_nterms"] = self.internal_switch.n_terms[0]
-            fl.attrs["switch_model"] = self.internal_switch.model.__name__.lower()
+            fl.attrs["switch_model"] = str(self.internal_switch.model)
             fl.attrs["t_load"] = self.open.spectrum.t_load
             fl.attrs["t_load_ns"] = self.open.spectrum.t_load_ns
 

--- a/src/edges_cal/modelling.py
+++ b/src/edges_cal/modelling.py
@@ -35,7 +35,7 @@ class FixedLinearModel:
     """
 
     model: Model = attr.ib()
-    x: np.ndarray = attr.ib(default=None, converter=np.asarray)
+    x: np.ndarray = attr.ib(converter=np.asarray)
     _init_basis: np.ndarray | None = attr.ib(
         default=None, converter=attr.converters.optional(np.asarray)
     )
@@ -46,11 +46,8 @@ class FixedLinearModel:
 
     @_init_basis.validator
     def _init_basis_vld(self, att, val):
-        if self.x is None and val is not None:
-            raise ValueError("Can only give init_basis if also giving x")
-
         if val is None:
-            return
+            return None
 
         if val.shape[1] != len(self.x):
             raise ValueError("The init_basis values must be the same shape as x.")

--- a/src/edges_cal/receiver_calibration_func.py
+++ b/src/edges_cal/receiver_calibration_func.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 """Functions for calibrating the receiver."""
+from __future__ import annotations
+
 import numpy as np
 import scipy as sp
-from typing import Iterable
+from typing import Sequence
 
 
 def temperature_thermistor(
-    resistance: [float, np.ndarray],
-    coeffs: [str, Iterable] = "oven_industries_TR136_170",
+    resistance: float | np.ndarray,
+    coeffs: str | Sequence = "oven_industries_TR136_170",
     kelvin: bool = True,
 ):
     """

--- a/src/edges_cal/reflection_coefficient.py
+++ b/src/edges_cal/reflection_coefficient.py
@@ -1,13 +1,16 @@
 """Functions for working with reflection coefficients."""
+from __future__ import annotations
+
 import numpy as np
 from edges_io import io
-from pathlib import Path
 from typing import List, Tuple, Union
+
+from . import types as tp
 
 
 def impedance2gamma(
-    z: [float, np.ndarray], z0: [float, np.ndarray]
-) -> [float, np.ndarray]:
+    z: float | np.ndarray, z0: float | np.ndarray,
+) -> float | np.ndarray:
     """Convert impedance to reflection coefficient.
 
     Parameters
@@ -26,8 +29,8 @@ def impedance2gamma(
 
 
 def gamma2impedance(
-    gamma: [float, np.ndarray], z0: [float, np.ndarray]
-) -> [float, np.ndarray]:
+    gamma: float | np.ndarray, z0: float | np.ndarray,
+) -> float | np.ndarray:
     """Convert reflection coeffiency to impedance.
 
     Parameters
@@ -54,7 +57,7 @@ def gamma_shifted(s11, s12s21, s22, r):  # noqa
 
 
 def s2p_read(
-    path: [str, Path]
+    path: tp.PathLike,
 ) -> Union[
     Tuple[np.ndarray, np.ndarray],
     Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray],

--- a/src/edges_cal/tools.py
+++ b/src/edges_cal/tools.py
@@ -7,6 +7,13 @@ from typing import List, Optional
 from .cached_property import cached_property
 
 
+def as_readonly(x: np.ndarray) -> np.ndarray:
+    """Get a read-only view into an array without copying."""
+    result = x.view()
+    result.flags.writeable = False
+    return result
+
+
 def dct_of_list_to_list_of_dct(dct: dict) -> List:
     """Take a dict of key: list pairs and turn it into a list of all combinations of dicts.
 

--- a/src/edges_cal/types.py
+++ b/src/edges_cal/types.py
@@ -1,0 +1,8 @@
+"""Simple type definitions for use internally."""
+from pathlib import Path
+from typing import Type, Union
+
+from edges_cal.modelling import Model
+
+PathLike = Union[str, Path]
+Modelable = Union[str, Type[Model]]

--- a/src/edges_cal/xrfi.py
+++ b/src/edges_cal/xrfi.py
@@ -1,11 +1,14 @@
 """Functions for excising RFI."""
+from __future__ import annotations
+
 import numpy as np
 import warnings
 import yaml
 from matplotlib import pyplot as plt
 from scipy import ndimage
-from typing import Optional, Tuple
+from typing import Any, Dict, Tuple
 
+from . import modelling as mdl
 from .modelling import Model, ModelFit
 
 
@@ -13,7 +16,7 @@ class NoDataError(Exception):
     pass
 
 
-def _check_convolve_dims(data, half_size: [None, Tuple[int, None]] = None):
+def _check_convolve_dims(data, half_size: Tuple[int] | None = None):
     """Check the kernel sizes to be used in various convolution-like operations.
 
     If the kernel sizes are too big, replace them with the largest allowable size
@@ -96,11 +99,11 @@ def robust_divide(num, den):
 
 def flagged_filter(
     data: np.ndarray,
-    size: [int, Tuple[int]],
+    size: int | Tuple[int],
     kind: str = "median",
-    flags: [None, np.ndarray] = None,
-    mode: [None, str] = None,
-    interp_flagged=True,
+    flags: np.ndarray | None = None,
+    mode: str | None = None,
+    interp_flagged: bool = True,
     **kwargs,
 ):
     """
@@ -191,8 +194,8 @@ def flagged_filter(
 
 def detrend_medfilt(
     data: np.ndarray,
-    flags: [None, np.ndarray] = None,
-    half_size: [None, Tuple[int, None]] = None,
+    flags: np.ndarray | None = None,
+    half_size: Tuple[int | None] | None = None,
 ):
     """Detrend array using a median filter.
 
@@ -260,8 +263,8 @@ def detrend_medfilt(
 
 def detrend_meanfilt(
     data: np.ndarray,
-    flags: [None, np.ndarray] = None,
-    half_size: [None, Tuple[int, None]] = None,
+    flags: np.ndarray | None = None,
+    half_size: Tuple[int | None] | None = None,
 ):
     """Detrend array using a mean filter.
 
@@ -308,15 +311,15 @@ def detrend_meanfilt(
 def xrfi_medfilt(
     spectrum: np.ndarray,
     threshold: float = 6,
-    flags: [None, np.ndarray] = None,
-    kf: [int, None] = 8,
-    kt: [int, None] = 8,
+    flags: np.ndarray | None = None,
+    kf: int = 8,
+    kt: int = 8,
     inplace: bool = True,
     max_iter: int = 1,
-    poly_order=0,
-    accumulate=False,
-    use_meanfilt=True,
-):
+    poly_order: int = 0,
+    accumulate: bool = False,
+    use_meanfilt: bool = True,
+) -> Tuple[np.ndarray, Dict[str, Any]]:
     """Generate RFI flags for a given spectrum using a median filter.
 
     Parameters
@@ -422,10 +425,8 @@ def xrfi_medfilt(
             resid[~new_flags] = (
                 spectrum[~new_flags]
                 - ModelFit(
-                    "polynomial",
-                    f[~new_flags],
+                    mdl.Polynomial(n_terms=poly_order).at(f[~new_flags]),
                     spectrum[~new_flags],
-                    n_terms=poly_order,
                 ).evaluate()
             )
             resid_list.append(resid)
@@ -464,13 +465,13 @@ def xrfi_medfilt(
 
 
 def xrfi_explicit(
-    spectrum: [None, np.ndarray] = None,
+    spectrum: np.ndarray | None = None,
     *,
     freq: np.ndarray,
-    flags: [None, np.ndarray] = None,
+    flags: np.ndarray | None = None,
     rfi_file=None,
     extra_rfi=None,
-):
+) -> np.ndarray[bool]:
     """
     Excise RFI from given data using an explicitly set list of flag ranges.
 
@@ -529,19 +530,17 @@ def _get_mad(x):
 def xrfi_model_sweep(
     spectrum: np.ndarray,
     *,
-    freq: Optional[np.ndarray] = None,
-    flags: [None, np.ndarray] = None,
-    weights: [None, np.ndarray] = None,
-    model_type: [str, Model] = "polynomial",
+    freq: np.ndarray | None = None,
+    flags: np.ndarray | None = None,
+    weights: np.ndarray | None = None,
+    model: Model = mdl.Polynomial(n_terms=3),
     window_width: int = 100,
     use_median: bool = True,
     n_bootstrap: int = 20,
-    n_terms: int = 3,
-    threshold: [None, float] = 3,
+    threshold: float | None = 3.0,
     which_bin: str = "last",
     watershed: int = 0,
-    max_iter=1,
-    **model_kwargs,
+    max_iter: int = 1,
 ) -> Tuple[np.ndarray, dict]:
     """
     Flag RFI by using a moving window and a low-order polynomial to detrend.
@@ -628,11 +627,7 @@ def xrfi_model_sweep(
     nf = len(spectrum)
     f = np.linspace(-1, 1, window_width)
 
-    # Create the model that will fit the spectrum/residuals
-    if isinstance(model_type, str):
-        model_type = Model._models[model_type.lower()](
-            default_x=f, n_terms=n_terms, **model_kwargs
-        )
+    model = model.at(x=f)
 
     # Initialize some flags, or set them equal to the input
     orig_flags = flags if flags is not None else np.zeros(nf, dtype=bool)
@@ -661,7 +656,7 @@ def xrfi_model_sweep(
     # Get the first window that has enough unflagged data.
     window = np.arange(window_width, dtype=int)
 
-    while np.sum(weights[window] > 0) <= model_type.n_terms and window[-1] < (nf - 1):
+    while np.sum(weights[window] > 0) <= model.n_terms and window[-1] < (nf - 1):
         window += 1
 
     if window[-1] == nf - 1:
@@ -673,7 +668,7 @@ def xrfi_model_sweep(
         spectrum,
         max_iter,
         weights,
-        model_type,
+        model,
         n_bootstrap,
         threshold,
         watershed,
@@ -694,7 +689,7 @@ def xrfi_model_sweep(
                 spectrum,
                 max_iter,
                 weights,
-                model_type,
+                model,
                 n_bootstrap,
                 threshold,
                 watershed,
@@ -708,7 +703,7 @@ def xrfi_model_sweep(
 
         window += 1
 
-    return flags, {"std": std, "params": params, "iters": iters, "model": model_type}
+    return flags, {"std": std, "params": params, "iters": iters, "model": model.model}
 
 
 xrfi_model_sweep.ndim = (1,)
@@ -720,7 +715,7 @@ def _flag_a_window(
     spectrum,
     max_iter,
     weights,
-    model_type,
+    model,
     n_bootstrap,
     threshold,
     watershed,
@@ -739,8 +734,8 @@ def _flag_a_window(
 
         mask = ~new_flags
 
-        if np.sum(mask) > model_type.n_terms:
-            fit = model_type.fit(ydata=d, weights=w)
+        if np.sum(mask) > model.n_terms:
+            fit = model.fit(ydata=d, weights=w)
         else:
             raise NoDataError
 
@@ -779,13 +774,12 @@ def xrfi_model(
     spectrum: np.ndarray,
     *,
     freq: np.ndarray,
-    model_type: [str, Model] = "polynomial",
-    resid_model_type: [str, Model] = "polynomial",
-    flags: [None, np.ndarray] = None,
-    weights: [None, np.ndarray] = None,
-    n_signal: int = 3,
+    model: Model = mdl.Polynomial(n_terms=3),
+    resid_model: Model = mdl.Polynomial(n_terms=5),
+    flags: np.ndarray | None = None,
+    weights: np.ndarray | None = None,
     n_resid: int = -1,
-    threshold: [None, float] = None,
+    threshold: float | None = None,
     max_iter: int = 20,
     accumulate: bool = False,
     increase_order: bool = True,
@@ -797,8 +791,7 @@ def xrfi_model(
     inplace: bool = False,
     watershed: int = 0,
     flag_if_broken: bool = True,
-    init_flags: [np.ndarray, Tuple[float, float], None] = None,
-    **model_kwargs,
+    init_flags: np.ndarray | Tuple[float, float] | None = None,
 ):
     """
     Flag RFI by subtracting a smooth model and iteratively removing outliers.
@@ -877,7 +870,7 @@ def xrfi_model(
 
     # We assume the residuals are smoother than the signal itself
     if not increase_order:
-        assert n_resid <= n_signal
+        assert n_resid <= model.n_terms
 
     if init_flags is not None and len(init_flags) == 2:
         init_flags = (freq > init_flags[0]) & (freq < init_flags[1])
@@ -892,17 +885,10 @@ def xrfi_model(
     model_std_list = []
     thresholds = []
 
-    # Create the model that will fit the spectrum/residuals
-    if isinstance(model_type, str):
-        model_type = Model.get_mdl(model_type)
-    if isinstance(resid_model_type, str):
-        resid_model_type = Model.get_mdl(resid_model_type)
-
-    model = model_type(default_x=freq, n_terms=n_signal, **model_kwargs)
-    res_model = resid_model_type(
-        default_x=freq,
-        n_terms=max(min_resid_terms, n_resid if n_resid > 0 else n_signal + n_resid),
-    )
+    model = model.at(x=freq)
+    res_model = resid_model.with_nterms(
+        max(min_resid_terms, n_resid if n_resid > 0 else model.n_terms + n_resid)
+    ).at(x=freq)
 
     # Initialize some flags, or set them equal to the input
     orig_flags = flags if flags is not None else np.zeros(nf, dtype=bool)
@@ -919,10 +905,10 @@ def xrfi_model(
     # requested maximum iterations, or until we have too few unflagged data to fit
     # appropriately. keep iterating
     while counter < max_iter and (
-        n_signal <= min_terms or (n_flags_changed > 0 and np.sum(~flags) > n_signal * 2)
+        model.n_terms <= min_terms
+        or (n_flags_changed > 0 and np.sum(~flags) > model.n_terms * 2)
     ):
 
-        model.update_nterms(n_signal)
         weights = np.where(flags, 0, orig_weights)
 
         # Get a model fit to the unflagged data.
@@ -952,8 +938,8 @@ def xrfi_model(
         # sigma=<any number>
         # \sqrt(exp(mean(log(Normal(0, \sigma, 1000000)^2))))/\sigma
         # it is not dependent on the value of sigma.
-        res_model.update_nterms(
-            max(min_resid_terms, n_resid if n_resid > 0 else n_signal + n_resid)
+        res_model = res_model.with_nterms(
+            max(min_resid_terms, n_resid if n_resid > 0 else model.n_terms + n_resid)
         )
         res_mdl = res_model.fit(ydata=np.log(absres ** 2), weights=weights)
         model_std = np.sqrt(np.exp(res_mdl.evaluate())) / 0.53
@@ -979,8 +965,8 @@ def xrfi_model(
             flags = new_flags.copy()
 
         counter += 1
-        if increase_order and n_signal < max_terms:
-            n_signal += 1
+        if increase_order and model.n_terms < max_terms:
+            model = model.with_nterms(model.n_terms + 1)
 
         thresholds.append(threshold)
 
@@ -998,7 +984,7 @@ def xrfi_model(
         if flag_if_broken:
             flags[:] = True
 
-    if np.sum(~flags) <= n_signal * 2:
+    if np.sum(~flags) <= model.n_terms * 2:
         warnings.warn(
             "Termination of iterative loop due to too many flags. Reduce n_signal or "
             "check data."
@@ -1028,12 +1014,12 @@ xrfi_model.ndim = (1,)
 
 
 def xrfi_watershed(
-    spectrum: [None, np.ndarray] = None,
+    spectrum: np.ndarray | None = None,
     *,
-    freq: [np.ndarray, None] = None,
-    flags: [None, np.ndarray] = None,
-    weights: [None, np.ndarray] = None,
-    tol: [float, Tuple[float]] = 0.5,
+    freq: np.ndarray | None = None,
+    flags: np.ndarray | None = None,
+    weights: np.ndarray | None = None,
+    tol: float | Tuple[float] = 0.5,
     inplace=False,
 ):
     """Apply a watershed over frequencies and times for flags.
@@ -1127,10 +1113,10 @@ def visualise_model_info(spectrum: np.ndarray, flags: np.ndarray, info: dict):
             info["thresholds"],
         )
     ):
-        model.update_nterms(len(pars))
-        res_model.update_nterms(len(res_pars))
+        model = model.with_params(pars)
+        res_model.with_params(pars)
 
-        m = model(parameters=pars)
+        m = model()
         res = spectrum - m
 
         ax[0, 0].plot(m, label=f"{len(pars)}: {nchange}/{tflags}")

--- a/src/edges_cal/xrfi.py
+++ b/src/edges_cal/xrfi.py
@@ -719,7 +719,7 @@ def _flag_a_window(
     n_bootstrap,
     threshold,
     watershed,
-    std_estimator=0,
+    std_estimator=2,
 ):
     # NOTE: line profiling reveals that the fitting takes ~50% of the time of this
     #       function, and taking the std takes ~20%. The next biggest are taking the

--- a/tests/test_cal_coeff.py
+++ b/tests/test_cal_coeff.py
@@ -37,9 +37,6 @@ def test_even_nterms_s11(cal_data):
     with pytest.raises(ValueError):
         s11.n_terms
 
-    with pytest.raises(ValueError):
-        s11.get_corrected_s11_model(n_terms=100)
-
 
 def test_lna_from_path(cal_data):
     lna = cc.LNA.from_path(cal_data)

--- a/tests/test_modelling.py
+++ b/tests/test_modelling.py
@@ -216,3 +216,31 @@ def test_yaml_roundtrip():
     pp = yaml.load(s)
     assert p == pp
     assert "!Model" in s
+
+
+def test_get_mdl_inst():
+    assert isinstance(mdl.get_mdl_inst("polynomial", n_terms=5), mdl.Polynomial)
+    poly = mdl.Polynomial(n_terms=5)
+    assert mdl.get_mdl_inst(poly) == poly
+    assert mdl.get_mdl_inst(poly, n_terms=6).n_terms == 6
+    assert mdl.get_mdl_inst(mdl.Polynomial, n_terms=5).n_terms == 5
+    assert mdl.Model.from_str("polynomial", n_terms=10).n_terms == 10
+
+
+def test_too_many_nterms():
+    with pytest.raises(ValueError):
+        mdl.PhysicalLin(n_terms=10)
+
+
+def test_at_x():
+    x1 = np.linspace(0, 1, 20)
+    first = mdl.Polynomial(n_terms=10).at(x=x1)
+    second = first.at_x(x1 * 2)
+    assert not np.allclose(first.basis, second.basis)
+    assert first.model == second.model
+
+
+def test_init_basis():
+    x = np.linspace(0, 1, 7)
+    with pytest.raises(ValueError):
+        mdl.Polynomial(n_terms=10).at(x=x, init_basis=np.zeros((10, 20)))


### PR DESCRIPTION
It now consists of smaller, self-consistent
  classes that are based on `attrs` and are read-only (but clonable). There is an
  explicit split between a `Model` and a `FixedLinearModel` which is defined at some
  coordinates `x`, allowing the latter to provide speedups for fitting lots of data at
  the same coordinates. They are also YAML-read/writable.

BREAKING CHANGE: Calls to Model need to be updated to not provide default_x.
    This can be provided by doing `Model().at(x=array)`.