### PR TITLE
feat: ability to specify a temperature range in LoadSpectrum

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     matplotlib
     cached_property
     astropy
-    edges-io>=3.0.0<4.0
+    edges-io<4.0
     toml
     pyyaml
     h5py

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     matplotlib
     cached_property
     astropy
-    edges-io>=3.0.0
+    edges-io>=3.0.0<4.0
     toml
     pyyaml
     h5py

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -14,7 +14,6 @@ import warnings
 import yaml
 from abc import ABCMeta, abstractmethod
 from astropy.convolution import Gaussian1DKernel, convolve
-from copy import copy
 from datetime import datetime, timedelta
 from edges_io import io
 from edges_io.logging import logger
@@ -785,6 +784,7 @@ class LoadSpectrum:
 
             temp_mask = np.zeros(spectra["Q"].shape[1], dtype=bool)
             for i, c in enumerate(self.get_thermistor_indices()):
+                print(i, c, self.thermistor_temp[c] if not np.isnan(c) else "nan")
                 if np.isnan(c):
                     temp_mask[i] = False
                 else:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -19,3 +19,21 @@ def test_read(ambient: LoadSpectrum):
 
 def test_datetimes(ambient: LoadSpectrum):
     assert len(ambient.thermistor_timestamps) == len(ambient.thermistor)
+
+
+def test_temperature_range(ambient: LoadSpectrum, data_path, tmpdir):
+    calpath = data_path / "Receiver01_25C_2019_11_26_040_to_200MHz"
+
+    with pytest.raises(RuntimeError, match="The temperature range has masked"):
+        # Fails only because our test data is awful. spectra and thermistor measurements
+        # don't overlap.
+        new = LoadSpectrum.from_load_name(
+            "ambient", calpath, cache_dir=tmpdir, temperature_range=0.5
+        )
+        new.n_integrations
+
+    with pytest.raises(RuntimeError, match="The temperature range has masked"):
+        new = LoadSpectrum.from_load_name(
+            "ambient", calpath, cache_dir=tmpdir, temperature_range=(20, 40)
+        )
+        new.n_integrations

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,15 +1,21 @@
 """
 Test spectrum reading.
 """
-from pathlib import Path
+import pytest
 
 from edges_cal import LoadSpectrum
 
 
-def test_read(data_path: Path, tmpdir: Path):
-
+@pytest.fixture(scope="module")
+def ambient(data_path, tmpdir) -> LoadSpectrum:
     calpath = data_path / "Receiver01_25C_2019_11_26_040_to_200MHz"
 
-    spec = LoadSpectrum.from_load_name("ambient", calpath, cache_dir=tmpdir)
+    return LoadSpectrum.from_load_name("ambient", calpath, cache_dir=tmpdir)
 
-    assert spec.averaged_Q.ndim == 1
+
+def test_read(ambient: LoadSpectrum):
+    assert ambient.averaged_Q.ndim == 1
+
+
+def test_datetimes(ambient: LoadSpectrum):
+    assert len(ambient.thermistor_timestamps) == len(ambient.thermistor)


### PR DESCRIPTION
This adds the `temperature_range` parameter to `LoadSpectrum` which allows one to cut on the temperatures used. This also necessitated being able to cross match timestamps from the spectra and thermistor measurements, which could come in handy for other things in the future.