### PR TITLE
fix: inject() method to use new attrs capabilities

### DIFF
--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -14,7 +14,6 @@ import warnings
 import yaml
 from abc import ABCMeta, abstractmethod
 from astropy.convolution import Gaussian1DKernel, convolve
-from copy import copy
 from edges_io import io
 from edges_io.logging import logger
 from functools import lru_cache
@@ -2311,8 +2310,7 @@ class CalibrationObservation:
         :class:`CalibrationObservation`
             A new observation object with the injected models.
         """
-        new = copy(self)
-        new.invalidate_cache()
+        new = self.clone()
         new._injected_lna_s11 = lna_s11
         new._injected_source_s11s = source_s11s
         new._injected_c1 = c1

--- a/tests/test_cal_coeff.py
+++ b/tests/test_cal_coeff.py
@@ -301,3 +301,16 @@ def test_basic_s11_properties(cal_data):
 
     assert calobs.open.reflections.match.load_name == "Match"
     assert calobs.open.reflections.match.repeat_num == 1
+
+
+def test_inject(cal_data):
+    calobs = cc.CalibrationObservation(cal_data, compile_from_def=False)
+    new = calobs.inject(
+        lna_s11=calobs.lna_s11 * 2,
+    )
+
+    np.testing.assert_allclose(new.lna_s11, 2 * calobs.lna_s11)
+    assert not np.allclose(
+        new.get_linear_coefficients("open")[0],
+        calobs.get_linear_coefficients("open")[0],
+    )


### PR DESCRIPTION
Simple fix for the `inject()` method for new attrs-based classes.