### PR TITLE
fix: simulate_qant call to receiver_s11

### DIFF
--- a/src/edges_cal/simulate.py
+++ b/src/edges_cal/simulate.py
@@ -145,7 +145,7 @@ def simulate_qant_from_calobs(
     ant_temp = loss * ant_temp / bm_corr + (1 - loss) * t_amb
 
     lna_s11 = (
-        calobs.receiver_s11(freq.to_value("MHz"))
+        calobs.receiver_s11(freq)
         if callable(calobs.receiver_s11)
         else calobs.receiver.s11_model(freq.to_value("MHz"))
     )


### PR DESCRIPTION
This just fixes a call to `calobs.receiver_s11` which requires Quantity input rather than ndarray.