### PR TITLE
fix: multiply by bm_corr instead of divide

### DIFF
--- a/src/edges_cal/simulate.py
+++ b/src/edges_cal/simulate.py
@@ -142,7 +142,7 @@ def simulate_qant_from_calobs(
 
     scale = scale_model(freq) if scale_model is not None else calobs.C1(freq)
 
-    ant_temp = loss * ant_temp / bm_corr + (1 - loss) * t_amb
+    ant_temp = loss * ant_temp * bm_corr + (1 - loss) * t_amb
 
     lna_s11 = (
         calobs.receiver_s11(freq)


### PR DESCRIPTION
This fixes a small issue with simulating q_ant from a calibration observation. It turns out you should multiply by the beam correction instead of dividing (when simulating), at least, if it's defined as in the bayesian calibration paper (and edges_estimate)