### PR TITLE
feat: add xrfi_model_nonlinear_window

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,7 +4,7 @@
 #
 # The repository labels will be automatically configured using this file and
 # the GitHub Action https://github.com/marketplace/actions/github-labeler.
-- name: API breaking
+- name: API Breaking
   description: Breaking Changes
   color: e305fc
 - name: good first issue

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,5 +11,3 @@ jobs:
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v4.1.0
-        with:
-          skip-delete: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     click
     statsmodels
     rich
-    hickleable>=0.2.1
+    hickleable>=0.2.4
 
 
 [options.packages.find]


### PR DESCRIPTION
This adds `xrfi_model_nonlinear_window` which in tests gets MUCH better agreement in flagging RFI with Alan's code. The only remaining discrepancy is in the model fits themselves, which are only accurate to the kelvin-level at first, and sub-kelvin at higher iterations.