### PR TITLE
fix: don't require provide proper InternalSwitch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - id: mixed-line-ending
     args: ['--fix=no']
 
-- repo: https://github.com/psf/black
+- repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.11.0
   hooks:
   - id: black

--- a/src/edges_cal/cal_coefficients.py
+++ b/src/edges_cal/cal_coefficients.py
@@ -1431,7 +1431,7 @@ class Calibrator:
             if not hasattr(val, f"{key}_model") or not callable(
                 getattr(val, f"{key}_model")
             ):
-                raise ValueError(f"internal_switch must provide {key}_model method")
+                warnings.warn(f"internal_switch does not provide {key}_model method")
 
     def _call_func(self, freq: tp.FreqType | None = None, *, key=None, norm=False):
         if freq is None:


### PR DESCRIPTION
This takes away the requirement to provide a proper `InternalSwitch` to get a working `Calibrator`. This was only really required to get the antenna S11 from S1P files in edges-analysis. We should find another route to do that.