### PR TITLE
fix: v0 calfile reader for hickle files

### DIFF
--- a/tests/test_calobs.py
+++ b/tests/test_calobs.py
@@ -235,3 +235,4 @@ def test_hickle_roundtrip(calobs, tmpdir):
 def test_read_version_zero(data_path: Path):
     calobs = cc.Calibrator.from_calfile(data_path / "calfiles/calfile_v0_hickled.h5")
     assert isinstance(calobs, cc.Calibrator)
+    calobs.internal_switch.s11_model(np.array([75.0]))

--- a/tests/test_calobs.py
+++ b/tests/test_calobs.py
@@ -236,3 +236,4 @@ def test_read_version_zero(data_path: Path):
     calobs = cc.Calibrator.from_calfile(data_path / "calfiles/calfile_v0_hickled.h5")
     assert isinstance(calobs, cc.Calibrator)
     calobs.internal_switch.s11_model(np.array([75.0]))
+    calobs.receiver_s11(np.array([75.0]) * u.MHz)


### PR DESCRIPTION
**Summary**
<!-- Provide a short summary of what this PR fixes. If the PR fixes any open Github issues, 
     added explicit lines like "Fixes #47" below your summary. -->

Fixes an issue with reading old v0 calfiles, which are written by hickle. It is not a perfect fix, as I can't figure out how to read the name of the model and transform classes, but it is a reasonable patch for the few cases we might need it.


<!-- NOTE: EVERYTHING BELOW CAN BE IGNORED FOR NOW. ONCE THE PR IS SUBMITTED, YOU CAN
     GO THROUGH THE CHECK-LISTS BELOW. ALSO REMEMBER TO ASSIGN A REVIEWER, AND ADD ANY
     LABELS YOU FEEL ARE APPROPRIATE.
-->

**Checklist:** <!-- note: this can be checked *after* submitting the PR! All must be checked before merging.-->
* [ ] A unit-test has been added which explicitly tests the bug that this PR fixes
* [ ] If I am a new contributor, I have added myself to the AUTHORS list
* [ ] I have added a succinct description of the fix to the CHANGELOG
* [ ] If the fix changes the way things work, I have updated relevant docstrings

**Meta-info:** <!-- note: these can be checked *after* submitting the PR. Only check those that are true -->
* [ ] These changes break strict backwards-compatibility <!-- merging will require increase major version number -->

