### PR TITLE
fix: smatrix class no slots

### DIFF
--- a/src/edges_cal/reflection_coefficient.py
+++ b/src/edges_cal/reflection_coefficient.py
@@ -311,7 +311,7 @@ class TwoPortNetwork:
         )
 
 
-@attrs.define(frozen=True, kw_only=False)
+@attrs.define(frozen=True, kw_only=False, slots=False)
 class SMatrix:
     """A scattering matrix for a two-port network.
 


### PR DESCRIPTION
Fixes the `SMatrix` class to not use slots.