### PR TITLE
fix: modelling error in lstsq fitting

### DIFF
--- a/src/edges_cal/modelling/fitting.py
+++ b/src/edges_cal/modelling/fitting.py
@@ -171,7 +171,7 @@ class ModelFit:
         rcond = y.size * np.finfo(y.dtype).eps
 
         # Determine the norms of the design matrix columns.
-        scl = np.sqrt(np.square(van).sum())
+        scl = np.sqrt(np.square(van.T).sum(axis=0))
 
         # Solve the least squares problem.
         return np.linalg.lstsq((van.T / scl), y.T, rcond)[0] / scl


### PR DESCRIPTION
Fixes #176 

This fixes the above issue -- the lstsq method was summing over all axes instead of just over the first axis, so the scaling of the problem wasn't good (i.e it was easily badly conditioned). 

Running the MWE provided by @akvydula now gives the following:

<img width="554" height="413" alt="Untitled" src="https://github.com/user-attachments/assets/8f25a1d5-92ce-445a-8fa4-9499a1346c72" />
